### PR TITLE
fixed where no error was showing when login was invalid

### DIFF
--- a/routes/users.js
+++ b/routes/users.js
@@ -148,11 +148,10 @@ router.post(
         loginUser(req, res, user);
         return res.redirect("/app");
       }
-      errors.push("Login failed for the provided email address and password");
     } else {
       errors = validatorErrors.array().map((error) => error.msg);
+      errors.push("Login failed for the provided email address and password");
     }
-    //errors.push("Login failed for the provided email address and password");
     res.render("user-login", {
       title: "Login",
       email,


### PR DESCRIPTION
When email / password was not valid for logging in, no error messages were shown other than the message "the following errors occurred". Now the correct error shows